### PR TITLE
Added Random Node-id for commissioning 

### DIFF
--- a/TC_PairUnpair.py
+++ b/TC_PairUnpair.py
@@ -19,6 +19,7 @@ import logging
 import time
 import argparse
 import sys
+import secrets
 
 import chip.CertificateAuthority
 import chip.clusters as Clusters
@@ -94,6 +95,8 @@ class TC_PairUnpair(MatterBaseTest):
 
     def commission_device(self):
         conf = self.matter_test_config
+        random_nodeid =  secrets.randbelow(2**32)  
+        conf.dut_node_ids = [random_nodeid ]
         for commission_idx, node_id in enumerate(conf.dut_node_ids):
             logging.info("Starting commissioning for root index %d, fabric ID 0x%016X, node ID 0x%016X" %
                          (conf.root_of_trust_index, conf.fabric_id, node_id))

--- a/Threadreset.py
+++ b/Threadreset.py
@@ -26,11 +26,6 @@ def thread_reset(data):
 
    ssh.close()
 
-   srpdisable = 'docker exec -ti otbr ot-ctl srp server disable'
-   subprocess.run(srpdisable , shell=True)
-   time.sleep(1)
-   srpenable = 'docker exec -ti otbr ot-ctl srp server enable'
-   subprocess.run(srpenable , shell=True)
 
    logging.info("Completed the reset")
 


### PR DESCRIPTION
- Added random node-id for commissioning in the conf object using secrets.randbelow(2**32) 
- Removed the SRP reset cmd's in the OTBR docker 